### PR TITLE
Corrigido erro com @date-io/date-fns após version bump

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
         "analyze": "source-map-explorer build/static/js/2.*.js"
     },
     "dependencies": {
-        "@date-io/date-fns": "2.5.0",
+        "@date-io/date-fns": "1.x",
         "@material-ui/core": "4.9.8",
         "@material-ui/icons": "4.9.1",
         "@material-ui/pickers": "3.2.10",

--- a/yarn.lock
+++ b/yarn.lock
@@ -933,22 +933,17 @@
   resolved "https://registry.yarnpkg.com/@csstools/normalize.css/-/normalize.css-9.0.1.tgz#c27b391d8457d1e893f1eddeaf5e5412d12ffbb5"
   integrity sha512-6It2EVfGskxZCQhuykrfnALg7oVeiI6KclWSmGDqB0AiInVrTGB9Jp9i4/Ad21u9Jde/voVQz6eFX/eSg/UsPA==
 
-"@date-io/core@1.x":
+"@date-io/core@1.x", "@date-io/core@^1.3.13":
   version "1.3.13"
   resolved "https://registry.yarnpkg.com/@date-io/core/-/core-1.3.13.tgz#90c71da493f20204b7a972929cc5c482d078b3fa"
   integrity sha512-AlEKV7TxjeK+jxWVKcCFrfYAk8spX9aCyiToFIiLPtfQbsjmRGLIhb5VZgptQcJdHtLXo7+m0DuurwFgUToQuA==
 
-"@date-io/core@^2.5.0":
-  version "2.5.0"
-  resolved "https://registry.yarnpkg.com/@date-io/core/-/core-2.5.0.tgz#afb3a82e989a925755cba139b71f95b6b396dce2"
-  integrity sha512-GifWlc0hyLdYwivltV8KVwE+OOVgYoHF4DvvKn6VOA73iVvqxbXXeL18PVFjMw8r0JUHmuhP6S+4TD8INBzXZA==
-
-"@date-io/date-fns@2.5.0":
-  version "2.5.0"
-  resolved "https://registry.yarnpkg.com/@date-io/date-fns/-/date-fns-2.5.0.tgz#10ff3b2220f1814e1d4d835dbfb9fb6f497e83aa"
-  integrity sha512-HiQqjVLFUPsOYtW3damMw5jsY5Yk2KG3LcI7s2eioce+jgxZ6XjhGiyWur14btgTVihhkVjfdzmd5XMfpRXH1Q==
+"@date-io/date-fns@1.x":
+  version "1.3.13"
+  resolved "https://registry.yarnpkg.com/@date-io/date-fns/-/date-fns-1.3.13.tgz#7798844041640ab393f7e21a7769a65d672f4735"
+  integrity sha512-yXxGzcRUPcogiMj58wVgFjc9qUYrCnnU9eLcyNbsQCmae4jPuZCDoIBR21j8ZURsM7GRtU62VOw5yNd4dDHunA==
   dependencies:
-    "@date-io/core" "^2.5.0"
+    "@date-io/core" "^1.3.13"
 
 "@emotion/hash@^0.8.0":
   version "0.8.0"


### PR DESCRIPTION
Corrigido erro com `@date-io/date-fns` após [version bump](https://github.com/dlx-lisbon/dlx-ui/commit/a51e6d614b9948156462c4e60018f44c05fc98a9).

O erro ocorria com material datepicker:
`Format string contains an unescaped latin alphabet character n`

O  [fix proposto](https://github.com/mui-org/material-ui-pickers/issues/1440#issuecomment-607133842) para isto é fixar a versão da dependência para `1.x`